### PR TITLE
Adds simple settings for prediction

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -1,4 +1,4 @@
-const registrationHalfInterval = 30;
+let registrationHalfInterval = 30;
 const timerUpdateInterval = 101;
 
 var offset = 0;
@@ -97,8 +97,10 @@ function updatePrediction() {
 	let req = new XMLHttpRequest();
 	req.open("GET", "predict.php");
 	req.addEventListener("load", function() {
-		let secs = parseInt(req.response);
-		prediction = new Date(secs);
+        let data = JSON.parse(req.response);
+	    console.log(data);  // Leave for debug purposes
+		prediction = new Date(data.ms + data.correction * 1000);
+        registrationHalfInterval = data.interval;
 		document.getElementById("prediction").innerHTML = dateString(prediction, "hh:mm:ss.sss");
 	});
 	req.send();

--- a/light.py
+++ b/light.py
@@ -7,6 +7,8 @@ import time
 import measure
 import logging
 import mail
+import settings
+import json
 
 def initialize_log():
     name = os.uname().nodename
@@ -28,7 +30,13 @@ if __name__ == "__main__":
 
     if args[0] == "predict":
         ms = int(measure.get_prediction().timestamp() * 1000)
-        print(ms)
+        correction = getattr(
+            settings, "CORRECTION_SECONDS", 0
+        )  # Correction to the regression
+        interval = getattr(settings, "ACCEPTABLE_INTERVAL", 30)
+        print(
+            json.dumps({"ms": ms, "correction": correction, "interval": interval})
+        )
     elif args[0] == "add":
         # add new time
         now = datetime.datetime.now()

--- a/measure.py
+++ b/measure.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import datetime
+import settings
 
 def read_times():
     times = []
@@ -58,4 +59,9 @@ def get_prediction():
 
 def time_is_reasonable(time):
     prediction = get_prediction()
-    return abs((time - prediction).total_seconds()) <= 30
+    prediction += datetime.timedelta(
+        seconds=getattr(settings, 'CORRECTION_SECONDS', 0)  # Correction to the regression
+    )
+    return abs((time - prediction).total_seconds()) <= int(getattr(
+        settings, "ACCEPTABLE_INTERVAL", 30
+    ))

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+CORRECTION_SECONDS = 0
+ACCEPTABLE_INTERVAL = 30


### PR DESCRIPTION
Adds a simple interface for prediction corrections

In `settings.py`, add some number of second to correct for in the prediction, and also choose some acceptable window width.
Using a python settings file also has the benefit that one might use python to simplify, like
```python
hour = 60 * 60
minute = 60
CORRECTION_SECONDS = 3 * hour + 5 * minute + 2
```
